### PR TITLE
Implement attendance check-in/out

### DIFF
--- a/rest/src/application/application.module.ts
+++ b/rest/src/application/application.module.ts
@@ -6,10 +6,19 @@ import { AuthController } from './controller/auth.controller';
 import { AuthLoginService } from './service/auth/auth-login.service';
 import { AuthRegisterService } from './service/auth/auth-register.service';
 import { UserController } from './controller/user.controller';
+import { AttendanceController } from './controller/attendance.controller';
+import { CheckInService } from './service/attendance/check-in.service';
+import { CheckOutService } from './service/attendance/check-out.service';
 
 @Module({
   imports: [forwardRef(() => DomainModule), InfrastructureModule],
-  controllers: [UserController, AuthController],
-  providers: [CreateUserService, AuthLoginService, AuthRegisterService],
+  controllers: [UserController, AuthController, AttendanceController],
+  providers: [
+    CreateUserService,
+    AuthLoginService,
+    AuthRegisterService,
+    CheckInService,
+    CheckOutService,
+  ],
 })
 export class ApplicationModule {}

--- a/rest/src/application/controller/attendance.controller.ts
+++ b/rest/src/application/controller/attendance.controller.ts
@@ -9,7 +9,7 @@ import { CheckOutService } from '../service/attendance/check-out.service';
 import { ApiBearerAuth } from '@nestjs/swagger';
 
 @ApiBearerAuth()
-@Controller('attendance')
+@Controller('attendances')
 @UseGuards(AuthGuard, RolesGuard)
 export class AttendanceController {
   constructor(

--- a/rest/src/application/controller/attendance.controller.ts
+++ b/rest/src/application/controller/attendance.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Post, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '../service/auth/auth.guard';
+import { RolesGuard } from '../service/rol/rolges.guard';
+import { Roles } from '../decorators/roles.decorator';
+import { CurrentUser } from '../decorators/current-user.decorator';
+import { RequestUser } from '../model/auth/auth.model';
+import { CheckInService } from '../service/attendance/check-in.service';
+import { CheckOutService } from '../service/attendance/check-out.service';
+import { ApiBearerAuth } from '@nestjs/swagger';
+
+@ApiBearerAuth()
+@Controller('attendance')
+@UseGuards(AuthGuard, RolesGuard)
+export class AttendanceController {
+  constructor(
+    private readonly checkInService: CheckInService,
+    private readonly checkOutService: CheckOutService,
+  ) {}
+
+  @Post('checkin')
+  @Roles('USER')
+  checkIn(@CurrentUser() user: RequestUser) {
+    return this.checkInService.execute(user);
+  }
+
+  @Post('checkout')
+  @Roles('USER')
+  checkOut(@CurrentUser() user: RequestUser) {
+    return this.checkOutService.execute(user);
+  }
+}

--- a/rest/src/application/service/attendance/check-in.service.ts
+++ b/rest/src/application/service/attendance/check-in.service.ts
@@ -1,0 +1,21 @@
+import { ConflictException, Inject, Injectable } from '@nestjs/common';
+import { ATTENDANCE_REPOSITORY_INTERFACE, IAttendanceRepository } from 'src/domain/model/attendance/attendance.repository';
+import { Attendance } from 'src/domain/model/attendance/attendance.entity';
+import { RequestUser } from 'src/application/model/auth/auth.model';
+
+@Injectable()
+export class CheckInService {
+  constructor(
+    @Inject(ATTENDANCE_REPOSITORY_INTERFACE)
+    private readonly attendanceRepository: IAttendanceRepository,
+  ) {}
+
+  async execute(currentUser: RequestUser): Promise<Attendance> {
+    const open = await this.attendanceRepository.findOpenByUserId(currentUser.userId!);
+    if (open) {
+      throw new ConflictException('User already checked in');
+    }
+    const attendance = new Attendance(null, currentUser.userId!, new Date(), null);
+    return this.attendanceRepository.create(attendance);
+  }
+}

--- a/rest/src/application/service/attendance/check-out.service.ts
+++ b/rest/src/application/service/attendance/check-out.service.ts
@@ -1,0 +1,21 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { ATTENDANCE_REPOSITORY_INTERFACE, IAttendanceRepository } from 'src/domain/model/attendance/attendance.repository';
+import { Attendance } from 'src/domain/model/attendance/attendance.entity';
+import { RequestUser } from 'src/application/model/auth/auth.model';
+
+@Injectable()
+export class CheckOutService {
+  constructor(
+    @Inject(ATTENDANCE_REPOSITORY_INTERFACE)
+    private readonly attendanceRepository: IAttendanceRepository,
+  ) {}
+
+  async execute(currentUser: RequestUser): Promise<Attendance> {
+    const open = await this.attendanceRepository.findOpenByUserId(currentUser.userId!);
+    if (!open) {
+      throw new BadRequestException('User has not checked in');
+    }
+    open.checkOut = new Date();
+    return this.attendanceRepository.update(open);
+  }
+}

--- a/rest/src/domain/model/attendance/attendance.entity.ts
+++ b/rest/src/domain/model/attendance/attendance.entity.ts
@@ -1,0 +1,12 @@
+import { BaseEntity } from '../base.entity.abstract';
+
+export class Attendance extends BaseEntity {
+  constructor(
+    public readonly id: string | null,
+    public readonly userId: string,
+    public checkIn: Date,
+    public checkOut: Date | null,
+  ) {
+    super(id);
+  }
+}

--- a/rest/src/domain/model/attendance/attendance.repository.ts
+++ b/rest/src/domain/model/attendance/attendance.repository.ts
@@ -1,0 +1,9 @@
+import { Attendance } from './attendance.entity';
+
+export const ATTENDANCE_REPOSITORY_INTERFACE = Symbol('IAttendanceRepository');
+
+export interface IAttendanceRepository {
+  create(attendance: Attendance): Promise<Attendance>;
+  findOpenByUserId(userId: string): Promise<Attendance | null>;
+  update(attendance: Attendance): Promise<Attendance>;
+}

--- a/rest/src/infrastructure/infrastructure.module.ts
+++ b/rest/src/infrastructure/infrastructure.module.ts
@@ -8,6 +8,8 @@ import { JwtModule } from '@nestjs/jwt';
 import { JwtService } from './service/auth/jwt.service';
 import { AUTH_INTERFACE } from 'src/application/model/auth/auth.interface';
 import { JwtStrategy } from './service/auth/jwt.strategy';
+import { AttendancePrismaRepository } from './prisma/repositories/attendance-prisma.repository';
+import { ATTENDANCE_REPOSITORY_INTERFACE } from 'src/domain/model/attendance/attendance.repository';
 
 @Module({
   imports: [PrismaModule, JwtModule.register({})],
@@ -20,6 +22,7 @@ import { JwtStrategy } from './service/auth/jwt.strategy';
     },
     UserPrismaRepository,
     CompanyPrismaRepository,
+    AttendancePrismaRepository,
     {
       provide: USER_REPOSITORY_INTERFACE,
       useClass: UserPrismaRepository,
@@ -28,12 +31,17 @@ import { JwtStrategy } from './service/auth/jwt.strategy';
       provide: COMPANY_REPOSITORY_INTERFACE,
       useClass: CompanyPrismaRepository,
     },
+    {
+      provide: ATTENDANCE_REPOSITORY_INTERFACE,
+      useClass: AttendancePrismaRepository,
+    },
   ],
   exports: [
     UserPrismaRepository,
     AUTH_INTERFACE,
     USER_REPOSITORY_INTERFACE,
     COMPANY_REPOSITORY_INTERFACE,
+    ATTENDANCE_REPOSITORY_INTERFACE,
   ],
 })
 export class InfrastructureModule {}

--- a/rest/src/infrastructure/prisma/repositories/attendance-prisma.repository.ts
+++ b/rest/src/infrastructure/prisma/repositories/attendance-prisma.repository.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../service/prisma.service';
+import { IAttendanceRepository } from 'src/domain/model/attendance/attendance.repository';
+import { Attendance } from 'src/domain/model/attendance/attendance.entity';
+import { Attendance as PrismaAttendance } from '@prisma/client';
+
+@Injectable()
+export class AttendancePrismaRepository implements IAttendanceRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(attendance: Attendance): Promise<Attendance> {
+    const record = await this.prisma.attendance.create({
+      data: {
+        userId: attendance.userId,
+        checkIn: attendance.checkIn,
+        checkOut: attendance.checkOut,
+      },
+    });
+    return this.toEntity(record);
+  }
+
+  async findOpenByUserId(userId: string): Promise<Attendance | null> {
+    const record = await this.prisma.attendance.findFirst({
+      where: { userId, checkOut: null },
+    });
+    return record ? this.toEntity(record) : null;
+  }
+
+  async update(attendance: Attendance): Promise<Attendance> {
+    const record = await this.prisma.attendance.update({
+      where: { id: attendance.id! },
+      data: {
+        checkOut: attendance.checkOut,
+      },
+    });
+    return this.toEntity(record);
+  }
+
+  private toEntity(record: PrismaAttendance): Attendance {
+    return new Attendance(record.id, record.userId, record.checkIn, record.checkOut);
+  }
+}

--- a/rest/src/infrastructure/prisma/schema.prisma
+++ b/rest/src/infrastructure/prisma/schema.prisma
@@ -32,6 +32,14 @@ model Company {
   users User[]
 }
 
+model Attendance {
+  id       String   @id @default(uuid())
+  userId   String
+  user     User     @relation(fields: [userId], references: [id])
+  checkIn  DateTime
+  checkOut DateTime?
+}
+
 enum Role {
   ADMIN
   MANAGER


### PR DESCRIPTION
## Summary
- allow users to check in and check out from work
- add Attendance model to Prisma schema
- implement attendance repository and services
- expose attendance controller and wire up providers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee7cfe73883229d7b57b7ae78677a