### PR TITLE
Fix token generation bug

### DIFF
--- a/rest/src/application/service/auth/auth-login.service.ts
+++ b/rest/src/application/service/auth/auth-login.service.ts
@@ -35,6 +35,8 @@ export class AuthLoginService {
     });
     await user.setRefreshToken(refreshToken);
 
+    await this.userRepository.update(user);
+
     return { token: accessToken, refreshToken };
   }
 }

--- a/rest/src/application/service/auth/auth-register.service.ts
+++ b/rest/src/application/service/auth/auth-register.service.ts
@@ -47,21 +47,23 @@ export class AuthRegisterService {
       'ADMIN',
     );
 
+    const createdUser = await this.userRepository.create(user);
+
     const accessToken = this.authService.generateAccessToken({
-      userId: user.id,
-      email: user.email,
-      role: user.role,
-      companyId: user.companyId,
+      userId: createdUser.id,
+      email: createdUser.email,
+      role: createdUser.role,
+      companyId: createdUser.companyId,
     });
     const refreshToken = this.authService.generateRefreshToken({
-      userId: user.id,
-      email: user.email,
-      role: user.role,
-      companyId: user.companyId,
+      userId: createdUser.id,
+      email: createdUser.email,
+      role: createdUser.role,
+      companyId: createdUser.companyId,
     });
-    await user.setRefreshToken(refreshToken);
+    await createdUser.setRefreshToken(refreshToken);
 
-    await this.userRepository.create(user);
+    await this.userRepository.update(createdUser);
 
     return { token: accessToken, refreshToken };
   }

--- a/rest/src/domain/model/user/user.repository.interface.ts
+++ b/rest/src/domain/model/user/user.repository.interface.ts
@@ -5,4 +5,5 @@ export interface IUserRepository {
   create(user: User): Promise<User>;
   findByEmail(email: string): Promise<User | null>;
   findById(id: string): Promise<User | null>;
+  update(user: User): Promise<User>;
 }

--- a/rest/src/infrastructure/prisma/repositories/user-prisma.repository.ts
+++ b/rest/src/infrastructure/prisma/repositories/user-prisma.repository.ts
@@ -32,6 +32,16 @@ export class UserPrismaRepository implements IUserRepository {
     return this.toEntity(createdUser);
   }
 
+  async update(user: User): Promise<User> {
+    const updatedUser = await this.prisma.user.update({
+      where: { id: user.id! },
+      data: {
+        refreshTokenHash: user.getRefreshTokenHash(),
+      },
+    });
+    return this.toEntity(updatedUser);
+  }
+
   private toEntity(prismaUser: PrismaUser): User {
     const user = new User(
       prismaUser.name,

--- a/rest/src/infrastructure/service/auth/jwt.service.ts
+++ b/rest/src/infrastructure/service/auth/jwt.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService as NestJsJwtService } from '@nestjs/jwt';
-import { TokenModel } from '../../../application/model/auth/auth.model';
+import { TokenModel, RequestUser } from '../../../application/model/auth/auth.model';
 import { IAuth } from 'src/application/model/auth/auth.interface';
 
 @Injectable()
@@ -11,23 +11,45 @@ export class JwtService implements IAuth {
     private readonly config: ConfigService,
   ) {}
 
-  generateAccessToken(payload: TokenModel): string {
-    return this.jwt.sign(payload, {
-      secret: this.config.get('JWT_ACCESS_SECRET'),
-      expiresIn: this.config.get('JWT_ACCESS_EXPIRES_IN'),
-    });
+  generateAccessToken(payload: RequestUser): string {
+    return this.jwt.sign(
+      {
+        sub: payload.userId,
+        email: payload.email,
+        role: payload.role,
+        companyId: (payload as any).companyId,
+      },
+      {
+        secret: this.config.get('JWT_ACCESS_SECRET'),
+        expiresIn: this.config.get('JWT_ACCESS_EXPIRES_IN'),
+      },
+    );
   }
 
-  generateRefreshToken(payload: TokenModel): string {
-    return this.jwt.sign(payload, {
-      secret: this.config.get('JWT_REFRESH_SECRET'),
-      expiresIn: this.config.get('JWT_REFRESH_EXPIRES_IN'),
-    });
+  generateRefreshToken(payload: RequestUser): string {
+    return this.jwt.sign(
+      {
+        sub: payload.userId,
+        email: payload.email,
+        role: payload.role,
+        companyId: (payload as any).companyId,
+      },
+      {
+        secret: this.config.get('JWT_REFRESH_SECRET'),
+        expiresIn: this.config.get('JWT_REFRESH_EXPIRES_IN'),
+      },
+    );
   }
 
   verifyRefreshToken(token: string): TokenModel {
-    return this.jwt.verify(token, {
+    const payload = this.jwt.verify(token, {
       secret: this.config.get('JWT_REFRESH_SECRET'),
-    });
+    }) as Record<string, unknown>;
+
+    return {
+      userId: (payload.sub as string) ?? null,
+      email: payload.email as string,
+      role: payload.role as never,
+    };
   }
 }


### PR DESCRIPTION
## Summary
- generate auth tokens after persisting the new user
- store the refresh token during login
- add update method to user repository
- sign JWTs with `sub` field

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68529e3b9d8c83228d8db63a0041c3cf