### PR TITLE
Add login/register pages with green theme

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3,6 +3,20 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+
+  /* green palette */
+  --primary-50: #f0fdf4;
+  --primary-100: #dcfce7;
+  --primary-200: #bbf7d0;
+  --primary-300: #86efac;
+  --primary-400: #4ade80;
+  --primary-500: #22c55e;
+  --primary-600: #16a34a;
+  --primary-700: #15803d;
+  --primary-800: #166534;
+  --primary-900: #14532d;
+
+  --color-primary: var(--primary-600);
 }
 
 @theme inline {
@@ -22,5 +36,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans), Arial, Helvetica, sans-serif;
 }

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,0 +1,26 @@
+export const metadata = {
+  title: 'Login',
+};
+
+export default function Login() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background text-foreground font-[family-name:var(--font-geist-sans)] p-4">
+      <form className="bg-primary-50 p-8 rounded shadow w-full max-w-sm space-y-4">
+        <h1 className="text-2xl font-bold text-center text-primary-700">Login</h1>
+        <input
+          type="email"
+          placeholder="Email"
+          className="block w-full border border-primary-300 rounded p-2 focus:outline-none focus:border-primary-500"
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          className="block w-full border border-primary-300 rounded p-2 focus:outline-none focus:border-primary-500"
+        />
+        <button type="submit" className="w-full bg-primary-600 text-background py-2 rounded hover:bg-primary-700">
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/web/src/app/register/page.tsx
+++ b/web/src/app/register/page.tsx
@@ -1,0 +1,31 @@
+export const metadata = {
+  title: 'Register',
+};
+
+export default function Register() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background text-foreground font-[family-name:var(--font-geist-sans)] p-4">
+      <form className="bg-primary-50 p-8 rounded shadow w-full max-w-sm space-y-4">
+        <h1 className="text-2xl font-bold text-center text-primary-700">Register</h1>
+        <input
+          type="email"
+          placeholder="Email"
+          className="block w-full border border-primary-300 rounded p-2 focus:outline-none focus:border-primary-500"
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          className="block w-full border border-primary-300 rounded p-2 focus:outline-none focus:border-primary-500"
+        />
+        <input
+          type="password"
+          placeholder="Confirm Password"
+          className="block w-full border border-primary-300 rounded p-2 focus:outline-none focus:border-primary-500"
+        />
+        <button type="submit" className="w-full bg-primary-600 text-background py-2 rounded hover:bg-primary-700">
+          Register
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -1,0 +1,29 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: 'var(--color-background)',
+        foreground: 'var(--color-foreground)',
+        primary: {
+          DEFAULT: 'var(--color-primary)',
+          50: 'var(--primary-50)',
+          100: 'var(--primary-100)',
+          200: 'var(--primary-200)',
+          300: 'var(--primary-300)',
+          400: 'var(--primary-400)',
+          500: 'var(--primary-500)',
+          600: 'var(--primary-600)',
+          700: 'var(--primary-700)',
+          800: 'var(--primary-800)',
+          900: 'var(--primary-900)',
+        },
+      },
+    },
+  },
+  plugins: [],
+}
+
+export default config


### PR DESCRIPTION
## Summary
- add Tailwind configuration for custom green palette
- declare global CSS variables for green theme
- create login and register pages styled with Tailwind

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856bf5398408322b0813d0f950812ad